### PR TITLE
JCropAdminImageWidget was removed from forms.py

### DIFF
--- a/django_jcrop/models.py
+++ b/django_jcrop/models.py
@@ -4,7 +4,7 @@
 from django.db import models
 from django import forms
 
-from .forms import JCropAdminImageWidget
+from .forms import JCropImageWidget as JCropAdminImageWidget
 
 
 class JCropImageField(models.ImageField):


### PR DESCRIPTION
I am guessing it was just a change of name. It seems to be working for me.
